### PR TITLE
Document c910-imprec-load-af

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,120 @@ sysctl option `vm.mmap_min_addr`. To reproduce the bug,
 
 - C910: tested on T-Head TH1520
 
+## C910 load access faults are imprecise and have wrong mtval/stval
+
+Load bus errors cause access faults. On affected variants, when the exception
+happens:
+
+- The exception is imprecise. The architectural state (e.g. `mepc`/`sepc`,
+  general purpose registers) seems to have advanced after the faulting
+  instruction. RISC-V exceptions must be precise and "imprecise exceptions" are
+  not permitted.
+- `mtval`/`stval` is incorrect. The value should be the virtual address on which
+  access is attempted. However, the actual value is the physical address.
+
+### PoC
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <signal.h>
+#include <ucontext.h>
+
+void handler(int sig, siginfo_t *info, void *ucontext_voidp) {
+	ucontext_t *ucontext = (ucontext_t *) ucontext_voidp;
+	unsigned long *regs = ucontext->uc_mcontext.__gregs;
+
+	printf("fault! pc = %#lx\n", regs[0]);
+	_Exit(1);
+}
+
+int main(int argc, char **argv) {
+	if (argc != 2) return 1;
+	unsigned long ul = strtoul(argv[1], 0, 0);
+	printf("pa = %#lx\n", ul);
+	unsigned long page = ul & -4096;
+	unsigned long off = ul - page;
+
+	int x = open("/dev/mem", O_RDWR);
+	if (x < 0) {
+		perror("open");
+		return 1;
+	}
+	void *ptr = mmap(0, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, x, page);
+	if (ptr == MAP_FAILED) {
+		perror("mmap");
+		return 1;
+	}
+	char *p = (char *)ptr + off;
+	printf("va = %p\n", p);
+	extern char load_address_is[];
+
+	printf("memory access pc is = %p\n", load_address_is);
+
+	struct sigaction sa = { 0 };
+	sa.sa_flags = SA_SIGINFO;
+	sa.sa_sigaction = handler;
+
+	// Uncomment to see epc in userspace
+	// sigaction(SIGSEGV, &sa, NULL);
+
+	asm volatile (
+	"load_address_is:\n\t"
+		"lb x0, (%0)\n\t"
+		"fence.i"
+		:
+		: "r"(p)
+		: "memory"
+	);
+	return 0;
+}
+```
+
+Run with physical address on which access can cause a bus error.
+
+```shell
+./mmiotest 0x4e00000003
+```
+
+Program output:
+
+```
+pa = 0x4e00000003
+va = 0x3fba593003
+memory access pc is = 0x2ae0d629c0
+Segmentation fault
+```
+
+Kernel output:
+
+```
+[ 2672.476997] mmaptest[3227]: unhandled signal 11 code 0x2 at 0x0000002ae0d629c4 in mmaptest[9c4,2ae0d62000+1000]
+...
+[ 2672.477064] epc : 0000002ae0d629c4 ra : 0000002ae0d629a6 sp : 0000003fea4bf770
+...
+[ 2672.477118] status: 0000000200004020 badaddr: 0000004e00000003 cause: 0000000000000005
+[ 2672.477130] Code: 0597 0000 8593 ea45 3c23 f0b4 3583 fb04 8003 0005 (100f) 0000
+```
+
+Note that
+
+- The `cause` is `5`, "Load access fault", an exception, which should be precise
+- The faulting `epc` points to the `fence.i` instruction *after* the `lb`
+  instruction.
+- The `badaddr` value (Linux's name for `mtval`/`stval`) is the physical
+  address, not virtual address
+
+### Affected variants
+
+- openC910: Confirmed by inspecting the Verilog code
+- C920v1: Tested on SG2042
+
 ## Reference
 
-This documentation is summarized from
+This documentation contains information summarized from
 [RISCVuzz: Discovering Architectural CPU Vulnerabilities via Differential Hardware Fuzzing](https://ghostwriteattack.com/riscvuzz.pdf),
 thanks for the authors' work!
 

--- a/c910-imprec-load-af.c
+++ b/c910-imprec-load-af.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <signal.h>
+#include <ucontext.h>
+
+void handler(int sig, siginfo_t *info, void *ucontext_voidp) {
+	ucontext_t *ucontext = (ucontext_t *) ucontext_voidp;
+	unsigned long *regs = ucontext->uc_mcontext.__gregs;
+
+	printf("fault! pc = %#lx\n", regs[0]);
+	_Exit(1);
+}
+
+int main(int argc, char **argv) {
+	if (argc != 2) return 1;
+	unsigned long ul = strtoul(argv[1], 0, 0);
+	printf("pa = %#lx\n", ul);
+	unsigned long page = ul & -4096;
+	unsigned long off = ul - page;
+
+	int x = open("/dev/mem", O_RDWR);
+	if (x < 0) {
+		perror("open");
+		return 1;
+	}
+	void *ptr = mmap(0, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, x, page);
+	if (ptr == MAP_FAILED) {
+		perror("mmap");
+		return 1;
+	}
+	char *p = (char *)ptr + off;
+	printf("va = %p\n", p);
+	extern char load_address_is[];
+
+	printf("memory access pc is = %p\n", load_address_is);
+
+	struct sigaction sa = { 0 };
+	sa.sa_flags = SA_SIGINFO;
+	sa.sa_sigaction = handler;
+
+	// Uncomment to see epc in userspace
+	// sigaction(SIGSEGV, &sa, NULL);
+
+	asm volatile (
+	"load_address_is:\n\t"
+		"lb x0, (%0)\n\t"
+		"fence.i"
+		:
+		: "r"(p)
+		: "memory"
+	);
+	return 0;
+}


### PR DESCRIPTION
C910 load access faults are imprecise and have wrong mtval/stval. This can be reproduced by any load from an address from which AXI returns an error.